### PR TITLE
Renaming app to meet `mix compile' expectations

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,8 @@ defmodule Mongo.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :mongo,
-      name: "mongo",
+    [ app: :"elixir-mongo",
+      name: "elixir-mongo",
       version: "0.3.0",
       elixir: "~> 0.14.1",
       source_url: "https://github.com/checkiz/elixir-mongo",

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"bson": {:git, "git://github.com/checkiz/elixir-bson.git", "006f2c08a73bd206c2d9681e2b66e0aca03832f0", [tag: "0.3"]}}


### PR DESCRIPTION
On Elixir 0.14.2 mix is looking for 'elixir-mongo.app' but the current
app file is 'mongo.app'. This seems to fix that issue.
