### PR TITLE
Fix bug where successful operations that were run in safe mode threw errors

### DIFF
--- a/lib/mongo_collection.ex
+++ b/lib/mongo_collection.ex
@@ -88,7 +88,7 @@ defmodule Mongo.Collection do
       Request.insert(collection, docs))
     case collection.opts[:wc] do
       nil -> {:ok, docs}
-      :safe -> case collection.db.getLastError do
+      :safe -> case Mongo.Db.getLastError(collection.db) do
         :ok -> {:ok, docs}
         error -> error
       end


### PR DESCRIPTION
Fixed a bug where setting safe mode resulted in the following error that occurred on a legitimate insert (The insert worked, but threw this error):

```elixir
iex> Mongo.Collection.insert_one(%{test: "tickle"}, collection)
** (KeyError) key :getLastError not found in: %Mongo.Db{auth: nil, mongo: %Mongo.Server{host: 'qa-vpc-ue1a-mongo1a.p.int', id_prefix: 59155, mode: :passive, opts: %{wc: :safe}, port: 27017, socket: #Port<0.5820>, timeout: 6000}, name: "test", opts: %{mode: :passive, timeout: 6000, wc: :safe}}
    (mongo) lib/mongo_collection.ex:91: Mongo.Collection.insert/2
    (mongo) lib/mongo_collection.ex:63: Mongo.Collection.insert_one/2
```

Now that legitimate insert works as expected:
```elixir
iex> Mongo.Collection.insert_one(%{test: "tickle"}, collection)
{:ok, %{test: "tickle"}}
```

And an illegitimate insert (in this case, an insert to a non-root node in a cluster) results in this:
```elixir
iex> Mongo.Collection.insert_one(%{test: "tickle"}, collection)
{:error,                 
 %{code: 10058, connectionId: 290992, err: "not master",
   lastOp: %Bson.Timestamp{inc: 0, ts: 0}, n: 0, ok: 1.0}}
```