### PR TITLE
Fail in unsupported Enumerable protocol functions according to documentation

### DIFF
--- a/lib/mongo_cursor.ex
+++ b/lib/mongo_cursor.ex
@@ -43,7 +43,7 @@ defmodule Mongo.Cursor do
     end
   end
 
-  defimpl Enumerable, for: Mongo.Cursor do
+  defimpl Enumerable do
 
     @doc """
     Reduce documents in the buffer into a value
@@ -70,11 +70,11 @@ defmodule Mongo.Cursor do
 
     @doc false
     #Not implemented use `Mongo.Collection.count/1`
-    def count(_cursor), do: {:ok, -1}
+    def count(_cursor), do: {:error, __MODULE__}
 
     @doc false
     #Not implemented
-    def member?(_, _cursor), do: {:ok, false}
+    def member?(_, _cursor), do: {:error, __MODULE__}
   end
 
 end

--- a/lib/mongo_find.ex
+++ b/lib/mongo_find.ex
@@ -75,7 +75,7 @@ defmodule Mongo.Find do
     %__MODULE__{find| mods: Map.put(find.mods, k, v)}
   end
 
-  defimpl Enumerable, for: Mongo.Find do
+  defimpl Enumerable do
 
     @doc """
     Executes the query and reduce retrieved documents into a value
@@ -112,6 +112,6 @@ defmodule Mongo.Find do
     @doc """
     Not implemented
     """
-    def member?(_, _), do: :not_implemented
+    def member?(_, _), do: {:error, __MODULE__}
   end
 end


### PR DESCRIPTION
As documented in http://elixir-lang.org/docs/stable/elixir/Enumerable.html#member?/2
unimplemented functions should return `{:error, __MODULE__}`, and then a default implementation would be used.

Also there is no need to add `:for` key in `defimpl` if it's inside the module that it is implementing.