### PR TITLE
Make it work with Elixir 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-language: erlang
-elixir: 1.0.4
+language: elixir
 services:
   - mongodb
 notifications:
-  recipients:
+  email:
     - jerp@checkiz.com
-sudo: false
+elixir:
+  - 1.0.2
+  - 1.1.1
 otp_release:
-  - 18.0
-before_script:
-  - sleep 15
-  - mix local.hex --force
-  - mix deps.get --only test
-script: "MIX_ENV=test mix do deps.get, test"
+  - 17.4
+  - 18.1
+sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mongo.Mixfile do
     [ app: :mongo,
       name: "mongo",
       version: "0.5.2",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0 or ~> 1.1",
       source_url: "https://github.com/checkiz/elixir-mongo",
       description: "MongoDB driver for Elixir",
       deps: deps(Mix.env),


### PR DESCRIPTION
Nothing changed on code or docs. Simply update the requirement on `mix.exs` and travis config.

Depends on https://github.com/checkiz/elixir-bson/pull/10 and a new release of `elixir-bson` to avoid compilation warnings.