### PR TITLE
Fix auth to send db's name to Mongo.Request.cmd

### DIFF
--- a/lib/mongo_db.ex
+++ b/lib/mongo_db.ex
@@ -39,9 +39,9 @@ defmodule Mongo.Db do
   @doc false
   # Authenticates a user to a database (or do it again after failure)
   def auth(%Mongo.Db{auth: nil}=db), do: {:ok, db}
-  def auth(%Mongo.Db{auth: {username, hash_password}}=db) do
+  def auth(%Mongo.Db{name: name, auth: {username, hash_password}}=db) do
     nonce = getnonce(db)
-    case Mongo.Request.cmd(db, %{authenticate: 1}, %{nonce: nonce, user: username, key: hash(nonce <> username <> hash_password)})
+    case Mongo.Request.cmd(name, %{authenticate: 1}, %{nonce: nonce, user: username, key: hash(nonce <> username <> hash_password)})
       |> Server.call do
       {:ok, resp} ->
         case resp.success do


### PR DESCRIPTION
When attempting to use the `Mongo.Db.auth/3` command I ran into an issue where the underying `Mongo.Request.cmd` was expecting the first argument to be the name of the database as a string, but was instead receiving the entire `%Mongo.Db{}` struct.

The relevant parts of my stacktrace:

```
** (exit) an exception was raised:
    ** (ArgumentError) argument error
        :erlang.byte_size(%Mongo.Db{auth: {"myuser", "4f75033e39d8b884aa7d88e2fadfe2cb"}, mongo: %Mongo.Server{host: 'localhost', id_prefix: 8457, mode: :passive, opts: %{}, port: 27017, socket: #Port<0.6963>, timeout: 6000}, name: "gretel_dev", opts: %{mode: :passive, timeout: 6000}})
        lib/mongo_request.ex:41: Mongo.Request.cmd/3
        lib/mongo_db.ex:44: Mongo.Db.auth/1
```

The fix is simple enough, though I didn't see any tests that would need to be modified. Let me know if I missed any of that.
