### PR TITLE
Support for Elixir 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
     - jerp@checkiz.com
 elixir:
   - 1.0.2
-  - 1.1.1
+  - 1.2.0
 otp_release:
-  - 18.1
+  - 18.2
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mongo.Mixfile do
     [ app: :mongo,
       name: "mongo",
       version: "0.5.4",
-      elixir: "~> 1.0 or ~> 1.1",
+      elixir: "~> 1.0 or ~> 1.1 or ~> 1.2",
       source_url: "https://github.com/checkiz/elixir-mongo",
       description: "MongoDB driver for Elixir",
       deps: deps(Mix.env),

--- a/test/mongo_cursor_test.exs
+++ b/test/mongo_cursor_test.exs
@@ -41,7 +41,7 @@ defmodule Mongo.Cursor.Test do
 
     Mongo.Collection.drop anycoll
 
-    items = 1..110 |> Enum.map fn r -> %{a: r, value: r} end
+    items = 1..110 |> Enum.map(fn r -> %{a: r, value: r} end)
 
     Mongo.Collection.insert(items, anycoll)
 


### PR DESCRIPTION
Same as for elixir-bson. Update travis config, some tweaks to avoid new warnings on 1.2 and update mix deps. 

Test is failing, but it was failing before already. Totally unrelated.
